### PR TITLE
Add twigStrictVariables option

### DIFF
--- a/src/PatternLab/PatternEngine/Twig/Loaders/PatternLoader.php
+++ b/src/PatternLab/PatternEngine/Twig/Loaders/PatternLoader.php
@@ -30,6 +30,7 @@ class PatternLoader extends Loader {
 		// set-up default vars
 		$twigDebug      = Config::getOption("twigDebug");
 		$twigAutoescape = Config::getOption("twigAutoescape");
+		$twigStrictVariables = Config::getOption("twigStrictVariables");
 		
 		// go through various places where things can exist
 		$filesystemLoaderPaths = array();
@@ -88,7 +89,7 @@ class PatternLoader extends Loader {
 		
 		// set-up Twig
 		$twigLoader = new \Twig_Loader_Chain($loaders);
-		$instance   = new \Twig_Environment($twigLoader, array("debug" => $twigDebug, "autoescape" => $twigAutoescape));
+		$instance   = new \Twig_Environment($twigLoader, array("debug" => $twigDebug, "autoescape" => $twigAutoescape, "strict_variables" => $twigStrictVariables));
 		
 		// customize Twig
 		TwigUtil::setInstance($instance);


### PR DESCRIPTION
Enable setting strict_variables mode in Twig which helps to minimize build errors when components and patterns are used withing a Twig 2.0 environment.